### PR TITLE
optimize the docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,11 @@ ADD . /hato
 RUN touch src/* && \
     cargo build -Z unstable-options --out-dir $OUT_DIR $CARGO_FLAGS
 
-FROM rustlang/rust:nightly
+FROM debian:stretch-slim
 
 ARG OUT_DIR=./target/docker/
-COPY --from=build /hato/$OUT_DIR/hato .
+COPY --from=build /hato/$OUT_DIR/hato /
 
 EXPOSE 8000
 
-CMD ["./hato"]
+CMD ["/hato"]


### PR DESCRIPTION
你们原始的 Dockerfile 构建出来的镜像太大了，有 1.72GB